### PR TITLE
Fix trailing newlines

### DIFF
--- a/backend/audio_agent.py
+++ b/backend/audio_agent.py
@@ -38,4 +38,4 @@ def main():
             print(f"[Error] {e}")
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/backend/audio_service.py
+++ b/backend/audio_service.py
@@ -61,4 +61,4 @@ async def health_check():
     return {"status": "healthy"}
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8001) 
+    uvicorn.run(app, host="0.0.0.0", port=8001)

--- a/backend/backend_agent.py
+++ b/backend/backend_agent.py
@@ -66,4 +66,4 @@ async def health_check():
     return {"status": "healthy"}
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8003) 
+    uvicorn.run(app, host="0.0.0.0", port=8003)

--- a/backend/coordinator_service.py
+++ b/backend/coordinator_service.py
@@ -77,4 +77,4 @@ async def health_check():
     return {"status": "healthy"}
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8002) 
+    uvicorn.run(app, host="0.0.0.0", port=8002)

--- a/backend/main.py
+++ b/backend/main.py
@@ -267,4 +267,3 @@ if __name__ == "__main__":
         timeout_keep_alive=WEBSOCKET_TIMEOUT,
         timeout_graceful_shutdown=30
     )
- 

--- a/backend/multi_agent_mcp.py
+++ b/backend/multi_agent_mcp.py
@@ -127,4 +127,4 @@ def run_agents():
 
 if __name__ == "__main__":
     print("Running MCP multi-agent simulation with real TTS...")
-    run_agents() 
+    run_agents()

--- a/backend/qwen_agent.py
+++ b/backend/qwen_agent.py
@@ -100,4 +100,4 @@ def main():
             console.print(f"[red]Error:[/red] {str(e)}")
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/backend/rag_agent.py
+++ b/backend/rag_agent.py
@@ -331,4 +331,4 @@ def main():
             console.print(f"[red]Error:[/red] {str(e)}")
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/backend/shared_context.py
+++ b/backend/shared_context.py
@@ -57,4 +57,4 @@ def health_check():
     return {"status": "healthy"}
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8004) 
+    uvicorn.run(app, host="0.0.0.0", port=8004)

--- a/backend/test_audio_service.py
+++ b/backend/test_audio_service.py
@@ -70,4 +70,4 @@ def test_audio_service():
 if __name__ == "__main__":
     print("Starting Audio Service Tests...")
     test_audio_service()
-    print("\nTests completed!") 
+    print("\nTests completed!")


### PR DESCRIPTION
## Summary
- ensure all backend scripts end with a single newline

## Testing
- `python3 backend/test_audio_service.py` *(fails: ModuleNotFoundError: No module named 'requests')*